### PR TITLE
Fix isses with neovim remote filepath command

### DIFF
--- a/src/Neovim.ts
+++ b/src/Neovim.ts
@@ -6,13 +6,14 @@ import * as os from "node:os";
 
 export default class Neovim {
   instance: ReturnType<typeof attach> | undefined;
-  process: ReturnType<typeof child_process["spawn"]> | undefined;
+  process: ReturnType<(typeof child_process)["spawn"]> | undefined;
   settings: EditInNeovimSettings;
   nvimBinary: ReturnType<typeof findNvim>["matches"][number];
 
   constructor(settings: EditInNeovimSettings) {
     this.settings = settings;
-    if (this.settings.pathToBinary) this.nvimBinary = { path: this.settings.pathToBinary };
+    if (this.settings.pathToBinary)
+      this.nvimBinary = { path: this.settings.pathToBinary };
     else this.nvimBinary = findNvim({ orderBy: "desc" }).matches[0];
   }
 
@@ -20,12 +21,12 @@ export default class Neovim {
     if (!this.instance) return Promise.resolve([]);
 
     return this.instance.buffers;
-  }
+  };
 
   async newInstance(adapter: FileSystemAdapter, file?: TFile | null) {
     if (this.process) {
       new Notice("Linked Neovim instance already running", 5000);
-return;
+      return;
     }
 
     this.process = child_process.spawn(
@@ -55,13 +56,15 @@ return;
     });
 
     this.instance = attach({ proc: this.process! });
-  };
+  }
 
   openFile = async (file: TFile | null) => {
     if (!file) return;
     if (!this.settings.supportedFileTypes.includes(file.extension)) return;
 
-    child_process.exec(`${this.nvimBinary.path} --server ${this.settings.listenOn} --remote ${file.path}`);
+    child_process.exec(
+      `${this.nvimBinary.path} --server ${this.settings.listenOn} --remote '${file.path}'`,
+    );
   };
 
   close = () => {


### PR DESCRIPTION
- missed quotes caused multiple buffer open per every spaces from markdown file title

hi i noticed multiple buffers opening after update it was caused by space between words from filename