### PR TITLE
Implements settings updates without requiring Obsidian reload

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -29,7 +29,6 @@ export default class EditInNeovimSettingsTab extends PluginSettingTab {
 
   display(): void {
     const { containerEl } = this;
-
     containerEl.empty();
 
     new Setting(containerEl)
@@ -44,13 +43,14 @@ export default class EditInNeovimSettingsTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.terminal = value;
             await this.plugin.saveSettings();
+            await this.plugin.updateNeovimInstance();
           }),
       );
 
     new Setting(containerEl)
       .setName("Neovim server location")
       .setDesc(
-        "The Neovim instance will be spawned using --listen and needs a socket or IP:PORT (not sure if sockets work so use at your own risk)",
+        "The Neovim instance will be spawned using --listen and needs a socket or IP:PORT (requires restart)",
       )
       .addText((text) =>
         text
@@ -59,13 +59,14 @@ export default class EditInNeovimSettingsTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.listenOn = value;
             await this.plugin.saveSettings();
+            new Notice("Restart Obsidian to apply the new server location");
           }),
       );
 
     new Setting(containerEl)
       .setName("Path to Neovim binary")
       .setDesc(
-        "Manual override for detecting nvim binary. It's recommended you add nvim to your PATH instead. (requires reload)",
+        "Manual override for detecting nvim binary. It's recommended you add nvim to your PATH instead. (requires restart)",
       )
       .addText((text) =>
         text
@@ -74,6 +75,7 @@ export default class EditInNeovimSettingsTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.pathToBinary = value;
             await this.plugin.saveSettings();
+            new Notice("Restart Obsidian to apply the new Neovim binary path");
           }),
       );
 
@@ -103,6 +105,7 @@ export default class EditInNeovimSettingsTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.supportedFileTypes = value.split(" ");
             await this.plugin.saveSettings();
+            await this.plugin.updateNeovimInstance();
           }),
       );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,30 +14,26 @@ export default class EditInNeovim extends Plugin {
   async onload() {
     await this.loadSettings();
     this.pluginChecks();
-
-    this.neovim = new Neovim(this.settings);
-    const adapter = this.app.vault.adapter as FileSystemAdapter;
-
-    if (this.settings.openNeovimOnLoad) this.neovim.newInstance(adapter);
+    await this.initNeovim();
 
     this.registerEvent(
       this.app.workspace.on("file-open", this.neovim.openFile),
     );
-
     this.registerEvent(
       this.app.workspace.on("quit", this.neovim?.close),
     );
 
-    // This adds a settings tab so the user can configure various aspects of the plugin
     this.addSettingTab(new EditInNeovimSettingsTab(this.app, this));
 
-    // TODO: Find a way to open a file here that doesn't rely on fixed wait time
     this.addCommand({
       id: "edit-in-neovim-new-instance",
       name: "Open Neovim",
-      callback: async () => await this.neovim
-        .newInstance(adapter)
-        .then(() => setTimeout(() => this.neovim.openFile(this.app.workspace.getActiveFile()), 1000)),
+      callback: async () => {
+        const adapter = this.app.vault.adapter as FileSystemAdapter;
+        await this.neovim
+          .newInstance(adapter)
+          .then(() => setTimeout(() => this.neovim.openFile(this.app.workspace.getActiveFile()), 1000));
+      },
     });
 
     this.addCommand({
@@ -45,6 +41,21 @@ export default class EditInNeovim extends Plugin {
       name: "Close Neovim",
       callback: async () => this.neovim.close,
     });
+  }
+
+  async initNeovim() {
+    const adapter = this.app.vault.adapter as FileSystemAdapter;
+    this.neovim = new Neovim(this.settings);
+    if (this.settings.openNeovimOnLoad) {
+      await this.neovim.newInstance(adapter);
+    }
+  }
+
+  async updateNeovimInstance() {
+    if (this.neovim) {
+      await this.neovim.close();
+      await this.initNeovim();
+    }
   }
 
   onunload() {
@@ -65,14 +76,11 @@ export default class EditInNeovim extends Plugin {
 
   pluginChecks() {
     const found = findNvim({ orderBy: "desc" });
-
     if (found.matches.length === 0) {
       new Notice("Edit In Neovim: No Valid nvim binary found T_T \n\n make sure neovim is installed and on your PATH", 5000);
     }
-
     if (!(this.app.vault.adapter instanceof FileSystemAdapter)) {
       new Notice("Edit In Neovim: unknown adapter, unable to access vault files", 5000);
     }
   }
 }
-


### PR DESCRIPTION
- Add immediate updates for terminal and supportedFileTypes settings
- Show notification for settings requiring restart (listenOn, pathToBinary)
- Add automatic Neovim instance reconnection on settings change
- Update settings descriptions to indicate which require restart

Fixes #11 