### PR TITLE
feat: tmux-hosted Neovim mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ This plugin will pop open a new terminal and runs neovim inside it (You can turn
 
 After that, every time you open a file inside of Obsidian, that same file will get opened as a new buffer (or focused if already open) inside of the listening neovim instance. This effectively gives you the "linked tabs" functionality you would get inside Obsidian, but with an external editor (in this case neovim) instead.
 
+## tmux-hosted Neovim (OSC52-friendly)
+
+If you rely on OSC52 clipboard plugins (for example `nvim-osc52`), you may prefer running Neovim inside a `tmux` session so the "server side" is always a real TUI.
+
+In settings, set:
+
+- `Neovim host mode` to `tmux session`
+- `tmux session name` to whatever you want (default: `obsidian`)
+
+Optional:
+
+- enable `Attach tmux on start` to have the plugin try to open a terminal and run `tmux attach -t <session>`
+- enable `Keep tmux session alive on quit` if you want the tmux session to survive Obsidian restarts
+
+Note: if `listenOn` is a TCP address (e.g. `127.0.0.1:2006`) and something is already listening on that port, tmux-hosted Neovim won't be able to start.
+
 ## Why?
 
 I know Obsidian has vim bindings, but I've built up my own Neovim config and customised it to my liking and that's where I like to edit text.

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ export default class EditInNeovim extends Plugin {
       this.app.workspace.on("file-open", this.neovim.openFile)
     );
 
-    this.registerEvent(this.app.workspace.on("quit", this.neovim?.close));
+    this.registerEvent(this.app.workspace.on("quit", this.neovim?.onObsidianQuit));
 
     // This adds a settings tab so the user can configure various aspects of the plugin
     this.addSettingTab(new EditInNeovimSettingsTab(this.app, this));
@@ -47,12 +47,12 @@ export default class EditInNeovim extends Plugin {
     this.addCommand({
       id: "edit-in-neovim-close-instance",
       name: "Close Neovim",
-      callback: async () => this.neovim.close,
+      callback: async () => this.neovim.close(),
     });
   }
 
   onunload() {
-    this.neovim?.close();
+    this.neovim?.onObsidianQuit();
   }
 
   async loadSettings() {


### PR DESCRIPTION
Adds an optional host mode to run Neovim inside a tmux session instead of spawning a standalone terminal.

Motivation: OSC52 clipboard plugins (e.g. nvim-osc52) work best when the Neovim *server* is a real TUI; tmux-hosted Neovim avoids clipboard issues seen with client/server workflows.

What’s included:
- New settings: host mode (nvim vs tmux), tmux session name (default: obsidian)
- Optional: auto-attach tmux on start; keep tmux session alive on quit (default off)
- Safety: detects TCP listen port conflicts to avoid silent failures

Notes:
- Uses default tmux server/socket (no extra socket config)
- Windows: tmux mode is not supported