### PR TITLE
feat: headless Neovim mode when terminal is empty

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -12,7 +12,7 @@ export interface EditInNeovimSettings {
 }
 
 export const DEFAULT_SETTINGS: EditInNeovimSettings = {
-  terminal: process.env.TERMINAL || "alacritty",
+  terminal: process.env.TERMINAL || "",
   listenOn: "127.0.0.1:2006",
   openNeovimOnLoad: true,
   supportedFileTypes: ["txt", "md", "css", "js", "ts", "tsx", "jsx", "json"],


### PR DESCRIPTION
Adds a headless spawn option when the terminal setting is empty/unset.

This allows running Neovim as a background server using: nvim --headless --listen ADDR

Obsidian continues to open files via: nvim --server ADDR --remote FILE